### PR TITLE
Makes git keep track of standard maven test directories

### DIFF
--- a/coding-exercise-plain-java/src/test/java/.gitignore
+++ b/coding-exercise-plain-java/src/test/java/.gitignore
@@ -1,0 +1,7 @@
+# This file makes git keep this directory even if it is empty.
+# (By default git stores only files effectively ignoring empty directories).
+#
+# This directory is important for IntelliJ IDEA.
+# IDEA doesn't create this directory automatically when importing maven project,
+# later it has problem when creating (JUnit) tests.
+# Tested with IntelliJ IDEA Community Edition 2018.3.5

--- a/coding-exercise-rest-jpa/src/test/java/.gitignore
+++ b/coding-exercise-rest-jpa/src/test/java/.gitignore
@@ -1,0 +1,7 @@
+# This file makes git keep this directory even if it is empty.
+# (By default git stores only files effectively ignoring empty directories).
+#
+# This directory is important for IntelliJ IDEA.
+# IDEA doesn't create this directory automatically when importing maven project,
+# later it has problem when creating (JUnit) tests.
+# Tested with IntelliJ IDEA Community Edition 2018.3.5

--- a/coding-exercise-spring-simple/src/test/java/.gitignore
+++ b/coding-exercise-spring-simple/src/test/java/.gitignore
@@ -1,0 +1,7 @@
+# This file makes git keep this directory even if it is empty.
+# (By default git stores only files effectively ignoring empty directories).
+#
+# This directory is important for IntelliJ IDEA.
+# IDEA doesn't create this directory automatically when importing maven project,
+# later it has problem when creating (JUnit) tests.
+# Tested with IntelliJ IDEA Community Edition 2018.3.5


### PR DESCRIPTION
Without these directories IntelliJ IDEA has a problem when it creates test classes. IDEA doesn't create these directories automatically during importing maven project.