### PR TITLE
POP-2767 add cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
     time: "04:00"
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: org.springframework.boot:spring-boot-starter-parent


### PR DESCRIPTION
Adding a cooldown of 7 days to the dependabot config to safeguard against supply-chain attacks.
